### PR TITLE
Adding the Theia fuse GFS service to labbernamespace.

### DIFF
--- a/labbernamespace/charts/gfsfuse/Chart.yaml
+++ b/labbernamespace/charts/gfsfuse/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gfsfuse
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/labbernamespace/charts/gfsfuse/templates/deployment.yaml
+++ b/labbernamespace/charts/gfsfuse/templates/deployment.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-gfsfuse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # role: gfsfuse
+    app: {{ .Release.Name }}-gfsfuse
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Release.Name }}
+    managed-by: helm
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-gfsfuse
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-gfsfuse
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+    spec:
+      containers:
+      - name: gfsfuse
+        # image: buildregistry.localdomain/gfs-fuse:latest
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 5006
+        env:
+        - name: LISTEN_ADDR
+          value: "0.0.0.0"
+        - name: LISTEN_PORT
+          value: "5005"
+        - name: GFSAPI_HOST
+          value: "{{ .Values.global.gfsapi.hostname }}" # {{ .Release.Name }}-gfsapi
+        - name: GFSAPI_PORT
+          value: "{{ .Values.global.gfsapi.port }}" # "5000"
+        - name: GFSAPI_NAMESPACE
+          value: "{{ .Values.global.gfsnamespace }}" # "buildkite"
+        - name: GFS_USERNAME
+          value: "{{ .Values.global.gfsapi.username }}" # "root"
+        - name: GFS_PASSWORD
+          value: "{{ .Values.global.gfsapi.password }}" # "root"
+        - name: LOG_LEVEL
+          value: "{{ .Values.global.loglevel }}" # "DEBUG"
+      # imagePullSecrets:
+      # - name: regcred
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-gfsfuse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # role: gfsfuse
+    app: {{ .Release.Name }}-gfsfuse
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Release.Name }}
+    managed-by: helm
+spec:
+  ports:
+  - name: port1
+    protocol: TCP
+    port: 5006
+    targetPort: 5006
+  selector:
+    # role: gfsfuse
+    app: {{ .Release.Name }}-gfsfuse
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-gfsfuse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    # role: gfsfuse
+    app: {{ .Release.Name }}-gfsfuse
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Release.Name }}
+    managed-by: helm
+  annotations:
+    kubernetes.io/ingress.class: "traefik"
+spec:
+  rules:
+  # - host: "{{ .Release.Name }}.localdomain"
+  # - host: "{{ .Values.global.domain.host }}.{{ .Values.global.domain.name }}"
+  - host: "gfs.{{ .Values.global.domain.name }}"
+    http:
+      paths:
+      - path: "/fuse/{{ .Values.global.gfsnamespace }}/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-gfsfuse
+            port:
+              number: 5006
+---

--- a/labbernamespace/charts/gfsfuse/templates/deployment.yaml
+++ b/labbernamespace/charts/gfsfuse/templates/deployment.yaml
@@ -30,16 +30,16 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: 5006
+        - containerPort: 3000
         env:
         - name: LISTEN_ADDR
           value: "0.0.0.0"
         - name: LISTEN_PORT
-          value: "5005"
+          value: "3000"
         - name: GFSAPI_HOST
           value: "{{ .Values.global.gfsapi.hostname }}" # {{ .Release.Name }}-gfsapi
         - name: GFSAPI_PORT
-          value: "{{ .Values.global.gfsapi.port }}" # "5000"
+          value: "{{ .Values.global.gfsapi.port }}" # "3000"
         - name: GFSAPI_NAMESPACE
           value: "{{ .Values.global.gfsnamespace }}" # "buildkite"
         - name: GFS_USERNAME
@@ -48,6 +48,19 @@ spec:
           value: "{{ .Values.global.gfsapi.password }}" # "root"
         - name: LOG_LEVEL
           value: "{{ .Values.global.loglevel }}" # "DEBUG"
+        # From the Sep 15, 2019 docker-compose.yaml
+        # privileged: true
+        # cap_add: 
+        #   - SYS_ADMIN
+        #   - MKNOD
+        # devices:
+        #   - "/dev/fuse:/dev/fuse"
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - MKNOD
       # imagePullSecrets:
       # - name: regcred
 ---
@@ -68,8 +81,8 @@ spec:
   ports:
   - name: port1
     protocol: TCP
-    port: 5006
-    targetPort: 5006
+    port: 3000
+    targetPort: 3000
   selector:
     # role: gfsfuse
     app: {{ .Release.Name }}-gfsfuse
@@ -102,5 +115,5 @@ spec:
           service:
             name: {{ .Release.Name }}-gfsfuse
             port:
-              number: 5006
+              number: 3000
 ---

--- a/labbernamespace/charts/gfsfuse/values.yaml
+++ b/labbernamespace/charts/gfsfuse/values.yaml
@@ -1,0 +1,5 @@
+
+image:
+  repository: buildregistry.localdomain/gfs-fuse
+  tag: latest
+  pullPolicy: Always

--- a/labbernamespace/values.yaml
+++ b/labbernamespace/values.yaml
@@ -60,3 +60,11 @@ gfssubscriber:
     repository: buildregistry.localdomain/gfs-subscriber
     tag: latest
     pullPolicy: Always
+
+
+gfsfuse:
+
+  image:
+    repository: buildregistry.localdomain/gfs-fuse
+    tag: latest
+    pullPolicy: Always


### PR DESCRIPTION
We had this old fuse mounter service that ran within the Theia IDE
wherein one could explore a GFS namespace via bash. I am importing
this service into the labbernamespace helm package. This package
includes all non core services that relate to a particular namespace.