### PR TITLE
Deploy Theia fuse GFS service to own host root.

### DIFF
--- a/labbernamespace/charts/gfsfuse/templates/deployment.yaml
+++ b/labbernamespace/charts/gfsfuse/templates/deployment.yaml
@@ -106,10 +106,12 @@ spec:
   rules:
   # - host: "{{ .Release.Name }}.localdomain"
   # - host: "{{ .Values.global.domain.host }}.{{ .Values.global.domain.name }}"
-  - host: "gfs.{{ .Values.global.domain.name }}"
+  # - host: "gfs.{{ .Values.global.domain.name }}"
+  - host: "fuse.{{ .Values.global.gfsnamespace }}.gfs.{{ .Values.global.domain.name }}"
     http:
       paths:
-      - path: "/fuse/{{ .Values.global.gfsnamespace }}/"
+      # - path: "/fuse/{{ .Values.global.gfsnamespace }}/"
+      - path: "/"
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
The Theia web service does not like to be deployed to a path context, i.e. it wants to be deployed to the root context. This is probably due to it being a react/node.js app. Hence we need to deploy it to its own hostname.